### PR TITLE
Fasttrips

### DIFF
--- a/Wrangler/Supplink.py
+++ b/Wrangler/Supplink.py
@@ -140,7 +140,7 @@ class Supplink(dict):
         if not isinstance(columns, list): raise NetworkException("Supplink.asList() requires columns argument as a list")
         for col in columns:
             data.append(getattr(self,col))
-        return result
+        return data
         
     def asDataFrame(self, columns=None):
         import pandas as pd


### PR DESCRIPTION
**GENERAL COMMENTS**

There is a conflict between populating fields (route_id, for instance) between using human-friendly values and values that relate back easily to CHAMP.  For instance, the route_id for AC Transit's line 218 could be represented by '40_218' or 'actransit_218'.  In general, I opted for the former as much of the human-friendly content is populated to other fields and it will likely ease integration with CHAMP.

**UPDATES**

1. fare_id and fare_class names have changed.  Previously, fare_id contained the suffix '_zone_x_to_y' where x and y could be either zone_ids or station names associated with those zone_ids, if those names were known.  Now that suffix is dropped and a new suffix is added, '_Zi' where i is and integer index.  All fares for a given operator and price, even if they have different origin/destination zones, will belong to the same fare_id.  The fare_class simply adds a time-of-day suffix to the fare_id, so the same simplification is reflected in fare_class, too.  This greatly reduces the number of fare_ids, fare_classes, and fare_transfer_rules.  The drawback is that the '_Zi' suffix is arbitrary and loses information about the origin/destination stations or zones.  But this information is included in fare_rules and fare_rules_ft.
	
2. fare_price has been updated.  Previously, fare_price was calculated from either 1) a base fare plus the cost of traversing a farelink, or 2) a base fare (which should always be 0) plus an OD fare.  Some lines have  both OD fares and cross farelinks.  Now these are calculated as base fare plus OD fare plus farelinks fare.
	
3. psuedo-random departure times now use lognormal distribution instead of normal distribution.