### PR TITLE
Adjust links to other parts of SHRP2 project

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,8 @@ The base network and resulting network are in the [Citilabs Cube](http://www.cit
 
 ## Creating GTFS-PLUS networks for Fast-Trips
 NetworkWrangler is also a library that takes Cube networks prepared for SF-CHAMP,
-along with various other (optional) inputs, and creates networks in GTFS-PLUS, a 
-GTFS-based network format developed for use with Fast-Trips, a dynamic transit 
+along with various other (optional) inputs, and creates networks in [GTFS-PLUS](https://github.com/osplanning-data-standards/GTFS-PLUS), a [GTFS](https://developers.google.com/transit/gtfs/reference)-based network format developed for use with [Fast-Trips](https://github.com/BayAreaMetro/fast-trips), a dynamic transit 
 passenger assignment model.  
-
-[issues](https://github.com/sfcta/NetworkWrangler/issues)  
-[repo](https://github.com/sfcta/NetworkWrangler/tree/fasttrips)  
-[GTFS](https://developers.google.com/transit/gtfs/reference)  
-[GTFS-PLUS](https://github.com/osplanning-data-standards/GTFS-PLUS)  
 
 Usage
 =======


### PR DESCRIPTION
@sdrewc -- Just wanted to add some breadcrumbs to help people find their way to GTFS-PLUS and/or Fast-Trips more easily.  After I moved those links into the paragraph, the issues and repo links seemed kind of lonely without an invitation to contribute, so I dropped them (but I don't feel strongly about this).